### PR TITLE
fixed tests that were failing because of hooks in template dir

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,7 +9,7 @@ setup_repo() {
   delete_repo
   mkdir -p $TEST_REPO
   cd $TEST_REPO
-  git init
+  git init --template bogus_template_dir_that_doesnt_exist
   cd -
 }
 


### PR DESCRIPTION
* if your git template directory contains hooks then
  the install_hook function blows up because it doesn't want
  to override your hook.
* modified setup_repo to pass --template with bogus directory
  to git init because that's the first thing git considers
  and thus trumps all other configuration options
* this fixes #1